### PR TITLE
Moved most of the cookie and network interaction to the injected page

### DIFF
--- a/WikipediaReadingLists.safariextension/Info.plist
+++ b/WikipediaReadingLists.safariextension/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2</string>
+	<string>0.3</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>Chrome</key>

--- a/WikipediaReadingLists.safariextension/Info.plist
+++ b/WikipediaReadingLists.safariextension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.3</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Global Page</key>

--- a/WikipediaReadingLists.safariextension/injected.js
+++ b/WikipediaReadingLists.safariextension/injected.js
@@ -1,5 +1,3 @@
-let canonicalPageTitle;
-
 function dispatchShow(what, message) {
     return Promise.resolve(safari.self.tab.dispatchMessage('wikiExtensionAddPageToReadingList:' + what, message));
 }
@@ -23,13 +21,8 @@ function parseTitleFromUrl(href) {
     return url.searchParams.has('title') ? url.searchParams.get('title') : url.pathname.replace('/wiki/', '');
 }
 
-function getCanonicalPageTitle() {
-    return Promise.resolve(canonicalPageTitle);
-}
-
 function addPageToDefaultList(url, listId, token) {
-    canonicalPageTitle = parseTitleFromUrl(document.querySelector('link[rel=canonical]').href);
-    return getCanonicalPageTitle()
+    return Promise.resolve(parseTitleFromUrl(document.querySelector('link[rel=canonical]').href))
     .then(title => fetch(readingListPostEntryUrlForOrigin(url.origin, listId, token), getAddToListPostOptions(url, title)))
     .then(res => res.json())
     .then(res => dispatchShow('showResult', {urlString: url.href, resString: JSON.stringify(res)}));

--- a/WikipediaReadingLists.safariextension/injected.js
+++ b/WikipediaReadingLists.safariextension/injected.js
@@ -92,7 +92,7 @@ safari.self.addEventListener('message', (event) => {
         const urlString = event.message;
         if (urlString) {
             const url = new URL(urlString);
-            handleClick(url).catch(err => dispatchShow('showError', {urlString: url.href, errString: err.toString()}));
+            handleClick(url).catch(err => dispatchShow('showError', {urlString: url.href, errString: JSON.stringify(err)}));
         }
     }
 }, false);

--- a/WikipediaReadingLists.safariextension/injected.js
+++ b/WikipediaReadingLists.safariextension/injected.js
@@ -1,5 +1,105 @@
-safari.self.addEventListener('message', (event) => {
-    if (event.name === 'wikiExtensionGetPageTitle') {
-        safari.self.tab.dispatchMessage('wikiExtensionSetPageTitle', document.querySelector('link[rel=canonical]').href);
+let canonicalPageTitle;
+
+function dispatchShow(what, message) {
+    return Promise.resolve(safari.self.tab.dispatchMessage('wikiExtensionAddPageToReadingList:' + what, message));
+}
+
+function readingListPostEntryUrlForOrigin(origin, listId, token) {
+    return `${origin}/api/rest_v1/data/lists/${listId}/entries/?csrf_token=${encodeURIComponent(token)}`;
+}
+
+function csrfFetchUrlForOrigin(origin) {
+    return `${origin}/w/api.php?action=query&format=json&formatversion=2&meta=tokens&type=csrf`;
+}
+
+function getCsrfToken(origin) {
+    return fetch(csrfFetchUrlForOrigin(origin), { credentials: 'same-origin' })
+    .then(res => res.json())
+    .then(res => res.query.tokens.csrftoken);
+}
+
+function parseTitleFromUrl(href) {
+    const url = new URL(href);
+    return url.searchParams.has('title') ? url.searchParams.get('title') : url.pathname.replace('/wiki/', '');
+}
+
+function getCanonicalPageTitle() {
+    return Promise.resolve(canonicalPageTitle);
+}
+
+function addPageToDefaultList(url, listId, token) {
+    canonicalPageTitle = parseTitleFromUrl(document.querySelector('link[rel=canonical]').href);
+    return getCanonicalPageTitle()
+    .then(title => fetch(readingListPostEntryUrlForOrigin(url.origin, listId, token), getAddToListPostOptions(url, title)))
+    .then(res => res.json())
+    .then(res => dispatchShow('showResult', {urlString: url.href, resString: JSON.stringify(res)}));
+}
+
+function getReadingListsUrlForOrigin(origin, next) {
+    let result = `${origin}/api/rest_v1/data/lists/`;
+    if (next) {
+        result = result.concat(`?next=${next}`);
     }
-});
+    return result;
+}
+
+function getDefaultListId(url, next) {
+    return fetch(getReadingListsUrlForOrigin(url.origin, next), { credentials: 'same-origin' })
+    .then(res => {
+        if (res.status < 200 || res.status > 399) {
+            return res.json().then(res => {
+                throw res;
+            });
+        } else {
+            return res.json();
+        }
+    })
+    .then(res => {
+        const defaultList = res.lists.filter(list => list.default)[0];
+        if (defaultList) {
+            return defaultList.id;
+        } else if (res.next) {
+            return getDefaultListId(url, res.next);
+        } else {
+            throw new Error("no default list");
+        }
+    });
+}
+
+function mobileToCanonicalHost(url) {
+    url.hostname = url.hostname.replace(/^m\./, '').replace('.m.', '.');
+    return url;
+}
+
+function getAddToListPostBody(url, title) {
+    return `project=${mobileToCanonicalHost(url).origin}&title=${encodeURIComponent(title)}`;
+}
+
+function getAddToListPostOptions(url, title) {
+    return {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        credentials: 'same-origin',
+        body: getAddToListPostBody(url, title)
+    }
+}
+
+function handleTokenResult(url, token) {
+    return token === '+\\'
+        ? dispatchShow('showLoginPrompt', {urlString: url.href})
+        : getDefaultListId(url).then(listId => addPageToDefaultList(url, listId, token));
+}
+
+function handleClick(url) {
+    return getCsrfToken(url.origin).then(token => handleTokenResult(url, token));
+}
+
+safari.self.addEventListener('message', (event) => {
+    if (event.name === 'wikiExtensionAddPageToReadingList') {
+        const urlString = event.message;
+        if (urlString) {
+            const url = new URL(urlString);
+            handleClick(url).catch(err => dispatchShow('showError', {urlString: url.href, errString: err.toString()}));
+        }
+    }
+}, false);

--- a/WikipediaReadingLists.safariextension/popup.js
+++ b/WikipediaReadingLists.safariextension/popup.js
@@ -49,7 +49,7 @@ function getBundledMessage(lang, keys) {
  * @param {Array<string>} keys message keys to request
  */
 function geti18nMessages(origin, keys) {
-    return fetch(geti18nMessageUrl(origin, keys), { credentials: 'same-origin' })
+    return fetch(geti18nMessageUrl(origin, keys), { credentials: 'omit' })
     .then(res => {
         if (!res.ok) {
             throw res;

--- a/WikipediaReadingLists.safariextension/popup.js
+++ b/WikipediaReadingLists.safariextension/popup.js
@@ -169,7 +169,7 @@ safari.application.addEventListener('message', (event) => {
         }
         case 'wikiExtensionAddPageToReadingList:showError': {
             const {urlString, errString} = event.message;
-            showAddToListFailureMessage(popover, tab, new URL(urlString), errString);
+            showAddToListFailureMessage(popover, tab, new URL(urlString), JSON.parse(errString));
             break;
         }
     }


### PR DESCRIPTION
When "keep me logged in" was not used during log in, the session cookie
is not accessible in the global page. By moving the network request to
fetch the CSRF token to the injected/content page (popups.js) this
works now.

So, the structure is more like this:
* global page: for UI + I18N
* injected page: network requests + DOM handling of current wiki page

Between those messages have to be dispatched. Care has to be taken that
only simple, cloneable objects are passed with the message as message
data.

Bug: T191998