### PR TITLE
Button activation state improvements

### DIFF
--- a/WikipediaReadingLists.safariextension/injected.js
+++ b/WikipediaReadingLists.safariextension/injected.js
@@ -176,6 +176,16 @@ function handleError(url, err) {
     }
 }
 
+function getPageNamespace() {
+    const nodes = document.querySelectorAll('script');
+    for (let i = 0; i < nodes.length; i++) {
+        const match = /"wgNamespaceNumber":\s*(\d+)/.exec(nodes[i].innerText);
+        if (match) {
+            return parseInt(match[1], 10);
+        }
+    }
+}
+
 safari.self.addEventListener('message', (event) => {
     if (event.name === 'wikiExtensionAddPageToReadingList') {
         const urlString = event.message;
@@ -183,5 +193,7 @@ safari.self.addEventListener('message', (event) => {
             const url = new URL(urlString);
             handleClick(url).catch(err => handleError(url, err));
         }
+    } else if (event.name === 'wikiExtensionGetPageNamespace') {
+        safari.self.tab.dispatchMessage('wikiExtensionFoundPageNamespace', { ns: getPageNamespace() });
     }
 }, false);

--- a/WikipediaReadingLists.safariextension/validate.js
+++ b/WikipediaReadingLists.safariextension/validate.js
@@ -25,24 +25,27 @@ function setEnabled(target, cond) {
     target.disabled = !cond;
 }
 
+let button;
+
 safari.application.addEventListener('validate', function (event) {
-    if (event.command === 'wikiAddToReadingList') {
-        const button = event.target;
-        button.disabled = true;
-        if (!(safari.application.activeBrowserWindow
-            && safari.application.activeBrowserWindow.activeTab
-            && safari.application.activeBrowserWindow.activeTab.url)) {
-            return;
-        }
-        const url = new URL(safari.application.activeBrowserWindow.activeTab.url);
-        setEnabled(button, isSupportedHost(url.hostname) && isSavablePage(url.pathname, url.searchParams));
-        safari.application.addEventListener('message', function (event) {
-            if (event.name === 'wikiExtensionFoundPageNamespace') {
-                console.log('foo');
-                console.log(event.message);
-                setEnabled(button, supportedNamespaces.includes(event.message.ns));
-            }
-        });
-        safari.application.activeBrowserWindow.activeTab.page.dispatchMessage('wikiExtensionGetPageNamespace');
+    if (event.command === 'wikiAddToReadingList') button = event.target;
+});
+
+safari.application.addEventListener('message', function (event) {
+    if (button && event.name === 'wikiExtensionFoundPageNamespace') {
+        setEnabled(button, supportedNamespaces.includes(event.message.ns));
+    }
+});
+
+safari.application.addEventListener('beforeNavigate', function (event) {
+    if (button) button.disabled = true;
+});
+
+safari.application.addEventListener('navigate', function (event) {
+    const rawUrl = event.target.url;
+    if (!rawUrl) return;
+    const url = new URL(rawUrl);
+    if (isSupportedHost(url.hostname) && isSavablePage(url.pathname, url.searchParams)) {
+        event.target.page.dispatchMessage('wikiExtensionGetPageNamespace');
     }
 });


### PR DESCRIPTION
Limits activation to when viewing pages in NS_MAIN, and fixes a bug in which it could be active for non-Wikimedia pages when using the back or forward buttons.